### PR TITLE
Clear the drawn polygon only on success

### DIFF
--- a/src/lib/osm/OsmLoader.svelte
+++ b/src/lib/osm/OsmLoader.svelte
@@ -53,6 +53,7 @@
       onload(new Uint8Array(osmXml), boundaryGj);
     } catch (err: any) {
       onerror?.(err.toString());
+      throw err;
     }
   }
 
@@ -99,8 +100,14 @@
     polygonTool = new PolygonTool(map);
     polygonTool.startNew();
     polygonTool.addEventListenerSuccess(async (f) => {
-      polygonTool = null;
-      await importPolygon(f);
+      try {
+        await importPolygon(f);
+        // Only clear after successful import
+        polygonTool = null;
+      } catch (err) {
+        // Keep polygonTool active on error so user can retry
+        // Error is already handled by onerror callback in importPolygon
+      }
     });
     polygonTool.addEventListenerFailure(() => {
       polygonTool = null;


### PR DESCRIPTION
ATM, when Overpass fails, the Polygon I just drew is removed.
This change is supposed to only remove the Polygon when the import worked.

I don't have a full setup to test this package in Speedwalk so this is not tested…

---

I recommend ignoring the issue should this not be a very simple change…