### PR TITLE
Add two Maptiler background options

### DIFF
--- a/src/lib/map/index.ts
+++ b/src/lib/map/index.ts
@@ -137,6 +137,14 @@ export let basemapStyles: SvelteMap<string, string | StyleSpecification> =
       `https://api.maptiler.com/maps/dataviz/style.json?key=${maptilerKey}`,
     ],
     [
+      "Maptiler Dataviz Light",
+      `https://api.maptiler.com/maps/dataviz-light/style.json?key=${maptilerKey}`,
+    ],
+    [
+      "Maptiler Dataviz Dark",
+      `https://api.maptiler.com/maps/dataviz-dark/style.json?key=${maptilerKey}`,
+    ],
+    [
       "Maptiler Dark",
       `https://api.maptiler.com/maps/dataviz-dark/style.json?key=${maptilerKey}`,
     ],


### PR DESCRIPTION
I think the light one will work nicely with Speedwalk because it has less color itself.

Demo at https://docs.maptiler.com/sdk-js/examples/built-in-styles/